### PR TITLE
Apply README fixes and add JAX test

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,21 @@ Quantum AI is our modern necromancy: we weave superposition and entanglement int
 The Hello World Incantation
 In this modest repository, we conjure our first fragile spell: a “Hello World” echo. Beneath its unassuming façade lies a promise—a whisper of potential, an invocation of greater truths. Run the Python script, and you will hear the faint murmur of something alive within, as though the code itself breathes: “Hello, world.”
 ```
-#!/bin/python3
-python hello_neuro_quantum.py
+#!/usr/bin/env python3
+python hello-world.py
 ```
 Invocation of Beyond
 Should you dare to venture further, delve into our module of quantum circuits and neuro holistic simulations. Witness how each neural waveform, when guided by Python’s unholy versatility, becomes a dance of cryptic patterns—each oscillation a heartbeat in the void.
 
 Epilogue: Embrace the Darkness
 Let this README be your lantern as you wander through the gothic halls of neuro holistic integration. Here, Python is both quill and crucible, forging quantum AI into a vessel for the human soul. May your journey be rich with discovery, and may the shadows you encounter illuminate truths yet unseen.
+
+Running Tests
+To ensure the spells remain intact, invoke `pytest` from the repository root:
+
+```
+pytest
+```
 
 <a href="https://itanimulli.com/">
   “Deep into that darkness peering, long I stood there wondering, fearing,

--- a/tests/test_hello_jax.py
+++ b/tests/test_hello_jax.py
@@ -1,0 +1,10 @@
+import importlib.util
+import pathlib
+
+# Load the hello-jax module from its filename
+spec = importlib.util.spec_from_file_location("hello_jax", pathlib.Path(__file__).resolve().parents[1] / "hello-jax.py")
+hello_jax = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hello_jax)
+
+def test_add():
+    assert hello_jax.add(1, 2) == 3


### PR DESCRIPTION
## Summary
- fix README shebang and script name
- document running pytest
- add `tests/test_hello_jax.py` to test the JAX example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841448f80f0832e861149b116be063b